### PR TITLE
Add an `error` event when tasks error, and `duration` field to `post-execute` event

### DIFF
--- a/classes/worker.php
+++ b/classes/worker.php
@@ -97,10 +97,12 @@ class Worker
         } catch (\Throwable $e) {
             $task->state = 'error';
             $task->error_message = $e->getMessage();
+            $this->event('error', [$task, $e]);
             \Log::error($e->getMessage(), array('exception' => $e));
         } catch (\Exception $e) {
             $task->state = 'error';
             $task->error_message = $e->getMessage();
+            $this->event('error', [$task, $e]);
             \Log::error($e->getMessage(), array('exception' => $e));
         } finally {
             $this->restartDB();

--- a/classes/worker.php
+++ b/classes/worker.php
@@ -88,9 +88,13 @@ class Worker
 
             $this->event('pre-execute', [$task]);
             $this->restartDB();
+
+            $execution_start_time = microtime(true);
             $result = call_user_func_array($task->task, $args);
+            $duration = microtime(true) - $execution_start_time;
+
             $this->restartDB();
-            $this->event('post-execute', [$task, $result]);
+            $this->event('post-execute', [$task, $result, $duration]);
 
             $task->state = 'success';
             $return = true;


### PR DESCRIPTION
We have `pre-execute` and `post-execute` events which clients can
attach callbacks to. This adds an `error` one to be able to also
react when a task fails.

It also adds a `duration` field to `post-execute`