### PR TITLE
Use Ramsey's UUID library when generating task IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ desktop.ini
 .settings
 nbproject/
 .idea
+vendor/
+composer.lock

--- a/classes/model/task.php
+++ b/classes/model/task.php
@@ -60,7 +60,7 @@ class Task extends \Orm\Model
      */
     public static function enqueue($task, $args = [], $priority = null)
     {
-        $uuid = \Ramsey\Uuid\Uuid::uuid4();
+        $uuid = \Ramsey\Uuid\Uuid::uuid4()->toString();
 
         $body = json_encode(array(
             'task' => $task,

--- a/classes/model/task.php
+++ b/classes/model/task.php
@@ -60,7 +60,7 @@ class Task extends \Orm\Model
      */
     public static function enqueue($task, $args = [], $priority = null)
     {
-        $uuid = \Str::random('uuid');
+        $uuid = \Ramsey\Uuid\Uuid::uuid4();
 
         $body = json_encode(array(
             'task' => $task,

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "composer/installers": "~1.0",
-        "php-amqplib/php-amqplib": "^2.6"
+        "php-amqplib/php-amqplib": "^2.6",
+        "ramsey/uuid": "^3.8"
     }
 }


### PR DESCRIPTION
The UUID function in Fuel core does not use a good source of entropy, instead using a faster Mersenne Twister algorithm (`mt_rand`) which seems to collide a lot.

We've got 48,059,104 unique IDs in production and we've seen over 1,600 collisions in the last 6 months. Ramsey's UUID library meanwhile uses the `random_bytes` function in PHP7+ (or a fallback using the `paragonie/random_compat` library), both of which use OpenSSL randomness which is more random.

This should reduce the number of effective collisions to zero, however the ultimate fix would involve regenerating the ID when it collides in the database.